### PR TITLE
Update links regarding minimessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ HexNicks is a simple nickname plugin that allows players to set their nickname t
 
 ## Features
 
-- Parsing via [MiniMessage](https://docs.adventure.kyori.net/minimessage.html) - here's a [handy website](https://webui.adventure.kyori.net/) to pracitce.
+- Parsing via [MiniMessage](https://docs.adventure.kyori.net/minimessage) - here's a [handy website](https://webui.adventure.kyori.net/) to practice.
 - Optimized support for Spigot and Paper. Forks of either should work as well.
 - [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/) support with the placeholder `%hexnicks_nick%` for player's nicknames.
 - MySQL storage support for users on BungeeCord/Velocity.
@@ -50,7 +50,7 @@ All permissions except `hexnicks.nick.other`, `hexnicks.nonick.other`, `hexnicks
 
 ### Introducing gradients!
 
-Unless changed in the config, legacy color codes (&c, &l, etc.) are not supported. They can be losely supported when the config option is enabled, but the plugin uses [MiniMessage](https://docs.adventure.kyori.net/minimessage.html) for colors and formatting.
+Unless changed in the config, legacy color codes (&c, &l, etc.) are not supported. They can be losely supported when the config option is enabled, but the plugin uses [MiniMessage](https://docs.adventure.kyori.net/minimessage) for colors and formatting.
 
 <img align="middle" src="https://i.imgur.com/zdn80Qe.png">
 

--- a/docs/docs/color-formatting.md
+++ b/docs/docs/color-formatting.md
@@ -4,10 +4,10 @@ title: Color Formatting
 slug: /color-formatting
 ---
 
-One of the most important parts of HexNicks is, of course, colors! With the addition of [MiniMessage](https://github.com/KyoriPowered/adventure-text-minimessage) there are now even more ways to customize colors in your nickname. HexNicks can support legacy colors but supports, and encourages, MiniMessage colors.
+One of the most important parts of HexNicks is, of course, colors! With the addition of [MiniMessage](https://github.com/KyoriPowered/adventure/tree/main/4/text-minimessage) there are now even more ways to customize colors in your nickname. HexNicks can support legacy colors but supports, and encourages, MiniMessage colors.
 
 ## MiniMessage Colors
-MiniMessage uses tags for colors and formatting. Tags have a start tag and an end tag. Start tags are mandatory (obviously), end tags aren’t. `<yellow>Hello <blue>World<yellow>!` and `<yellow>Hello <blue>World</blue>!` and even `<yellow>Hello </yellow><blue>World</blue><yellow>!</yellow>` all do the same. Read the full documentation for MiniMessage [here](https://docs.adventure.kyori.net/minimessage#format).
+MiniMessage uses tags for colors and formatting. Tags have a start tag and an end tag. Start tags are mandatory (obviously), end tags aren’t. `<yellow>Hello <blue>World<yellow>!` and `<yellow>Hello <blue>World</blue>!` and even `<yellow>Hello </yellow><blue>World</blue><yellow>!</yellow>` all do the same. Read the full documentation for MiniMessage [here](https://docs.adventure.kyori.net/minimessage/format).
 
 ## Legacy Colors
 These are the color codes that a lot of people are still used to. Codes like `&a`, `&l`, `&x&r&r&g&g&b&b`. These are called legacy codes because the Minecraft chat, and other things, does not use raw strings anymore. By default, HexNicks will not parse these codes. If you want to use them in your nicknames you need to enable `legacy-support` in the config.
@@ -17,6 +17,6 @@ These are the color codes that a lot of people are still used to. Codes like `&a
 If enabled these codes will be parsed and probably work fine, though you will not receive support for issues relating to legacy codes.
 
 ## Gradients
-Everyone's favorite thing as of late, gradients! Gradients are parsed using MiniMessage, and you can read the documentation for them [here](https://docs.adventure.kyori.net/minimessage#gradient).
+Everyone's favorite thing as of late, gradients! Gradients are parsed using MiniMessage, and you can read the documentation for them [here](https://docs.adventure.kyori.net/minimessage/format#gradient).
 
 > View nickname examples using gradients here.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Config file for HexNicks by Majekdor | Have questions? Ask here: https://discord.majek.dev
-# For colors this config uses MiniMessage (https://docs.adventure.kyori.net/minimessage.html#the-components)
+# For colors this config uses MiniMessage (https://docs.adventure.kyori.net/minimessage/format#standard-tags)
 
 # Whether nicknames should show in the tab list
 tab-nicks: false


### PR DESCRIPTION
As per KyoriPowered/adventure-docs#45, the documentation for minimessage was split up into two pages and no longer uses a fragment in the link. While old links still continue to work, they don't directly bring the user directly to the format page as before.

I've also fixed references to minimessage's repo which is merged into adventure's monorepo and a typo I noticed while making the PR

Similar changes should probably also be made in the wiki, if that is still in use