### PR TITLE
Missing links

### DIFF
--- a/docs/docs/color-formatting.md
+++ b/docs/docs/color-formatting.md
@@ -19,4 +19,4 @@ If enabled these codes will be parsed and probably work fine, though you will no
 ## Gradients
 Everyone's favorite thing as of late, gradients! Gradients are parsed using MiniMessage, and you can read the documentation for them [here](https://docs.adventure.kyori.net/minimessage/format#gradient).
 
-> View nickname examples using gradients here.
+> View nickname examples using gradients [here](https://docs.adventure.kyori.net/minimessage/format#gradient).

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -4,7 +4,7 @@ title: Commands
 slug: /commands
 ---
 
-The main plugin command you'll be using is `/nick` to change your nickname, but all of the commands in the plugin are explained below. This page will reference color codes a lot, you can read about color formatting [here](https://docs.adventure.kyori.net/minimessage/format#color).
+The main plugin command you'll be using is `/nick` to change your nickname, but all of the commands in the plugin are explained below. This page will reference color codes a lot, you can read about color formatting [here](https://hexnicks.majek.dev/color-formatting).
 
 ## /nick
 

--- a/docs/docs/commands.md
+++ b/docs/docs/commands.md
@@ -4,7 +4,7 @@ title: Commands
 slug: /commands
 ---
 
-The main plugin command you'll be using is `/nick` to change your nickname, but all of the commands in the plugin are explained below. This page will reference color codes a lot, you can read about color formatting here.
+The main plugin command you'll be using is `/nick` to change your nickname, but all of the commands in the plugin are explained below. This page will reference color codes a lot, you can read about color formatting [here](https://docs.adventure.kyori.net/minimessage/format#color).
 
 ## /nick
 

--- a/docs/docs/permissions.md
+++ b/docs/docs/permissions.md
@@ -40,13 +40,13 @@ This permission node is intended for staff and allows them to use [/nicksreload]
 
 This permission node is a dangerous one to grant as it allows players to inject things like hover events and click-to-run-command events into chat. Players without this permission will only be able to use MiniMessage tags for colors in chat. This permission allows them to use all MiniMessage tags in chat.
 
-> Read about chat formatting [here](https://github.com/MajekDev/HexNicks/wiki/Chat-Formatting).
+> Read about chat formatting [here](https://hexnicks.majek.dev/chat-formatting).
 
 ## hexnicks.color.*
 
 This permission node allows players to use all standard color codes (ex. \<red\>, \<dark_blue\>) in their nicknames. You can specify only specific colors with `hexnicks.color.red` (or any of the other 16 Mincraft color names).
 
-> Read about color formatting [here](https://github.com/MajekDev/HexNicks/wiki/Color-Formatting).
+> Read about color formatting [here](https://hexnicks.majek.dev/color-formatting).
 
 ## hexnicks.color.hex
 
@@ -56,7 +56,7 @@ This permission node allows players to use hex color codes (ex. \<#aabbcc\>, \<c
 
 This permission node allows players to use gradients in their nicknames.
 
-> See gradient examples here.
+> See gradient examples [here](https://hexnicks.majek.dev/color-formatting#gradients).
 
 ## Blocking Certain Color Usage
 


### PR DESCRIPTION
There are a couple of files where you're missing a link for "here". I think I've found the appropriate links, but you can evaluate my PR to be sure. Otherwise, in the permissions file, there were a few links that were redirecting from the wiki to the docs page. To avoid the experience of the redirect, I replaced with the link directly to the doc.