### PR TITLE
Fix concurrency issue with JSON backed storage in v3

### DIFF
--- a/src/main/java/dev/majek/hexnicks/storage/JsonStorage.java
+++ b/src/main/java/dev/majek/hexnicks/storage/JsonStorage.java
@@ -61,7 +61,7 @@ public class JsonStorage implements StorageMethod {
   }
 
   @Override
-  public void removeNick(@NotNull UUID uuid) {
+  public synchronized void removeNick(@NotNull UUID uuid) {
     HexNicks.core().getNickMap().remove(uuid);
     try {
       JsonObject json = (JsonObject) JsonParser.parseReader(new FileReader(HexNicks.core().jsonFile()));


### PR DESCRIPTION
Since this also writes to the file, it should also be synchronized to ensure two writes never happen at the same time.