### PR TITLE
Add functionality to announce player nicks on join

### DIFF
--- a/src/main/java/dev/majek/hexnicks/config/ConfigValues.java
+++ b/src/main/java/dev/majek/hexnicks/config/ConfigValues.java
@@ -43,6 +43,7 @@ import org.jetbrains.annotations.NotNull;
 public class ConfigValues {
 
   public Boolean              TAB_NICKS;
+  public Boolean              ANNOUNCE_NICKS_ON_JOIN;
   public Integer              MAX_LENGTH;
   public Integer              MIN_LENGTH;
   public Boolean              REQUIRE_ALPHANUMERIC;
@@ -68,6 +69,7 @@ public class ConfigValues {
    */
   public void reload() {
     TAB_NICKS = HexNicks.core().getConfig().getBoolean("tab-nicks", false);
+    ANNOUNCE_NICKS_ON_JOIN = HexNicks.core().getConfig().getBoolean("announce-nicks-on-join", false);
     MAX_LENGTH = HexNicks.core().getConfig().getInt("max-length", 20);
     MIN_LENGTH = HexNicks.core().getConfig().getInt("min-length", 3);
     REQUIRE_ALPHANUMERIC = HexNicks.core().getConfig().getBoolean("require-alphanumeric", false);

--- a/src/main/java/dev/majek/hexnicks/config/Messages.java
+++ b/src/main/java/dev/majek/hexnicks/config/Messages.java
@@ -115,6 +115,11 @@ public interface Messages {
 
   Args0 NOT_ALLOWED = () -> MiscUtils.configString("messages.notAllowed", "<red>That nickname is not allowed!");
 
+  Args2<Player, Component> ANNOUNCE_NICK = (player, nickname) -> MiscUtils
+          .configStringPlaceholders("messages.joinAnnouncement", "<yellow>%player% has the nickname</yellow> %nick%", player)
+          .replaceText(TextReplacementConfig.builder().matchLiteral("%player%").replacement(player.getName()).build())
+          .replaceText(TextReplacementConfig.builder().matchLiteral("%nick%").replacement(nickname).build());
+
   /**
    * A message that has no arguments that need to be replaced.
    */
@@ -135,6 +140,10 @@ public interface Messages {
     default void send(CommandSender sender, A0 arg0) {
       MiscUtils.sendMessage(sender, build(arg0));
     }
+
+    default void announce(A0 arg0) {
+      MiscUtils.announceMessage(build(arg0));
+    }
   }
 
   /**
@@ -145,6 +154,10 @@ public interface Messages {
 
     default void send(CommandSender sender, A0 arg0, A1 arg1) {
       MiscUtils.sendMessage(sender, build(arg0, arg1));
+    }
+
+    default void announce(A0 arg0, A1 arg1) {
+      MiscUtils.announceMessage(build(arg0, arg1));
     }
   }
 }

--- a/src/main/java/dev/majek/hexnicks/event/PlayerJoin.java
+++ b/src/main/java/dev/majek/hexnicks/event/PlayerJoin.java
@@ -46,9 +46,12 @@ public class PlayerJoin implements Listener {
     HexNicks.storage().hasNick(player.getUniqueId()).whenCompleteAsync((aBoolean, throwable) -> {
       if (aBoolean) {
         HexNicks.logging().debug("Player " + player.getName() + " joined and has nickname, setting...");
-        HexNicks.storage().getNick(player.getUniqueId()).whenCompleteAsync((component, throwable1) ->
-            HexNicks.core().setNick(player, component)
-        );
+        HexNicks.storage().getNick(player.getUniqueId()).whenCompleteAsync((component, throwable1) -> {
+          if (HexNicks.config().ANNOUNCE_NICKS_ON_JOIN) {
+            Messages.ANNOUNCE_NICK.announce(player, component);
+          }
+          HexNicks.core().setNick(player, component);
+        });
       } else {
         HexNicks.logging().debug("Player " + player.getName() + " joined and has no nickname.");
       }

--- a/src/main/java/dev/majek/hexnicks/util/MiscUtils.java
+++ b/src/main/java/dev/majek/hexnicks/util/MiscUtils.java
@@ -40,6 +40,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -233,6 +234,19 @@ public class MiscUtils {
   public static void sendMessage(final @NotNull CommandSender recipient, final @NotNull Component message) {
     if (!PlainTextComponentSerializer.plainText().serialize(message).isEmpty()) {
       recipient.sendMessage(message);
+    }
+  }
+
+  /**
+   * Announce a message to the server provided the message isn't empty.
+   *
+   * @param message the message to send
+   */
+  public static void announceMessage(final @NotNull Component message) {
+    if (!PlainTextComponentSerializer.plainText().serialize(message).isEmpty()) {
+      for (Player player : Bukkit.getOnlinePlayers()) {
+        player.sendMessage(message);
+      }
     }
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,9 @@
 # Whether nicknames should show in the tab list
 tab-nicks: false
 
+# Whether nicknames should be announced when players join
+announce-nicks-on-join: false
+
 # The maximum number of characters (excluding color codes) a nickname may be
 max-length: 20
 
@@ -102,3 +105,4 @@ messages:
   latestLog: "<green>View the latest log <click:open_url:'%link%'><aqua><u>here</u></aqua></click>."
   working: "<gray>Working..."
   notAllowed: "<red>That nickname is not allowed!"
+  joinAnnouncement: "<yellow>%player% has the nickname</yellow> %nick%"


### PR DESCRIPTION
Adds:
* Config flag `announce-nicks-on-join`
  * Default to `false`
* Config message `messages.joinAnnouncement`
  * Default to `"<yellow>%player% has the nickname</yellow> %nick%"`
* Functionality to announce Hexnicks messages server-wide